### PR TITLE
Add Params for AWS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This gem follows SemVer.
 
+## 2.1.0 - 2019-04-15
+
+### Fixed
+* Use `Dropzone.options.params` instead of `input` elements as there is no `form`
+
 ## 2.0.2 - 2019-04-03
 
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    et_dropzone_uploader (2.0.2)
+    et_dropzone_uploader (2.1.0)
       dropzonejs-rails (~> 0.8)
       rack-proxy (~> 0.6.5)
       rails (~> 5.2.2)

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ en:
 Add this line to your application's Gemfile (please note the `tag` should be your desired version):
 
 ```ruby
-gem 'et_dropzone_uploader', git: 'https://github.com/hmcts/et_dropzone_uploader.git', tag: 'v0.2.0'
+gem 'et_dropzone_uploader', git: 'https://github.com/hmcts/et_dropzone_uploader.git', tag: 'v2.1.0'
 ```
 
 And then execute:

--- a/app/assets/javascripts/et_dropzone_uploader/uploadAdditionalInformation.js
+++ b/app/assets/javascripts/et_dropzone_uploader/uploadAdditionalInformation.js
@@ -2,7 +2,6 @@ Dropzone.autoDiscover = false;
 window.EtDropzoneUploader = {};
 window.EtDropzoneUploader.init = (formId, uploadKeyId, fileNameId) => {
 
-    const uploadForm = $(formId);
     let provider;
 
     // Source:
@@ -17,19 +16,18 @@ window.EtDropzoneUploader.init = (formId, uploadKeyId, fileNameId) => {
         dropzoneUploadForm.options.url = url;
     }
 
-    function prepareAwsHiddenInputs(formContainer, fullResponseData) {
+    function prepareAwsHiddenInputs(fullResponseData) {
         // TODO: RST-1676 Remove this code
-        const responseData = fullResponseData.data;
-
-        formContainer.append(
-            `<input type='hidden' name='key' id='aws_key' value='${responseData.fields["key"]}'>`,
-            `<input type='hidden' name='policy' id='aws_policy' value='${responseData.fields["policy"]}'>`,
-            `<input type='hidden' name='x-amz-algorithm' id='aws_x-amz-algorithm' value='${responseData.fields["x-amz-algorithm"]}'>`,
-            `<input type='hidden' name='x-amz-credential' id='aws_x-amz-credential' value='${responseData.fields["x-amz-credential"]}'>`,
-            `<input type='hidden' name='x-amz-date' id='aws_x-amz-date' value='${responseData.fields["x-amz-date"]}'>`,
-            `<input type='hidden' name='x-amz-signature' id='aws_x-amz-signature' value='${responseData.fields["x-amz-signature"]}'>`,
-            `<input type='hidden' name='success_action_status' id='success_action_status' value='${responseData.fields["success_action_status"]}'>`
-        );
+        const responseData = fullResponseData.data.fields;
+        dropzoneUploadForm.options.params = {
+            key: responseData["key"],
+            policy: responseData["policy"],
+            "x-amz-algorithm": responseData["x-amz-algorithm"],
+            "x-amz-credential": responseData["x-amz-credential"],
+            "x-amz-date": responseData["x-amz-date"],
+            "x-amz-signature": responseData["x-amz-signature"],
+            success_action_status: responseData["success_action_status"]
+        };
     }
 
     function buildUpload(cb) {
@@ -150,7 +148,7 @@ window.EtDropzoneUploader.init = (formId, uploadKeyId, fileNameId) => {
                     })
                 } else {
                     // TODO: RST-1676 Remove the 'else' statement
-                    prepareAwsHiddenInputs(uploadForm, presignedData);
+                    prepareAwsHiddenInputs(presignedData);
                     uploadKey = presignedData.data.fields.key;
                     setUploadUrl(presignedData.data.url);
                     removedButton = removeButtonElement($("#upload-button"));

--- a/lib/et_dropzone_uploader/version.rb
+++ b/lib/et_dropzone_uploader/version.rb
@@ -1,3 +1,3 @@
 module EtDropzoneUploader
-  VERSION = '2.0.2'
+  VERSION = '2.1.0'
 end


### PR DESCRIPTION
### Change description ###

In `v2.0.2` I removed the `form` element in favour of using a generic `div` element, as the gem could then be embedded within existing `form` elements. Unfortunately, this broke AWS mode as AWS needs presigned inputs. This version of the gem uses the `Dropzone.options.params`, which effectively adds strings to the upload as if they were inputs to a form.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
