### PR TITLE
Recognise Existing Files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This gem follows SemVer.
 
+## 2.2.0 - 2019-05-10
+
+### Added 
+* Recognise existing file within parent Rails fields upon initialisation
+
+### Fixed
+* Delete key when removing file
+
 ## 2.1.1 - 2019-04-29
 
 ### Security

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    et_dropzone_uploader (2.1.1)
+    et_dropzone_uploader (2.2.0)
       dropzonejs-rails (~> 0.8)
       rack-proxy (~> 0.6.5)
       rails (~> 5.2.2)

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ en:
 Add this line to your application's Gemfile (please note the `tag` should be your desired version):
 
 ```ruby
-gem 'et_dropzone_uploader', git: 'https://github.com/hmcts/et_dropzone_uploader.git', tag: 'v2.1.1'
+gem 'et_dropzone_uploader', git: 'https://github.com/hmcts/et_dropzone_uploader.git', tag: 'v2.2.0'
 ```
 
 And then execute:

--- a/app/assets/javascripts/et_dropzone_uploader/uploadAdditionalInformation.js
+++ b/app/assets/javascripts/et_dropzone_uploader/uploadAdditionalInformation.js
@@ -121,7 +121,15 @@ window.EtDropzoneUploader.init = (formId, uploadKeyId, fileNameId) => {
             });
             this.on("removedfile", function () {
                 $(fileNameId).val(null);
+                $(uploadKeyId).val(null);
             });
+
+            if ($(fileNameId).val()){
+                let existingFile = { name: $(fileNameId).val(), type: 'application/rtf' };
+                this.options.addedfile.call(this, existingFile);
+                existingFile.previewElement.classList.add('dz-success');
+                existingFile.previewElement.classList.add('dz-complete');
+            }
         },
         // Set "Remove File" string by locale
         dictRemoveFile: localisedRemoveFileString(),

--- a/lib/et_dropzone_uploader/version.rb
+++ b/lib/et_dropzone_uploader/version.rb
@@ -1,3 +1,3 @@
 module EtDropzoneUploader
-  VERSION = '2.1.1'
+  VERSION = '2.2.0'
 end


### PR DESCRIPTION
### Change description ###

The gem now recognises whether there's an existing file in the Rails application it's embedded within. If there is, it will show the same screen it shows upon upload completion immediately.

Bump to v2.2.0 and update docs, etc.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
